### PR TITLE
ts の build target を es5 に

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,6 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
-    "target": "esnext"
+    "target": "es5"
   }
 }


### PR DESCRIPTION
esnext だと IE で使えないので