### PR TITLE
build: remove babel plugins

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -4,5 +4,4 @@ module.exports = {
     '@babel/preset-typescript',
     '@babel/preset-react',
   ],
-  plugins: ['@babel/plugin-proposal-optional-chaining', '@babel/plugin-proposal-nullish-coalescing-operator'],
 }

--- a/package.json
+++ b/package.json
@@ -45,8 +45,6 @@
   "devDependencies": {
     "@babel/cli": "^7.8.3",
     "@babel/core": "^7.8.3",
-    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
-    "@babel/plugin-proposal-optional-chaining": "^7.8.3",
     "@babel/preset-env": "^7.8.3",
     "@babel/preset-react": "^7.8.3",
     "@babel/preset-typescript": "^7.8.3",


### PR DESCRIPTION
optional-chaining and nullish-coalescing are included in preset-env now.