### PR TITLE
feat(use-toggle): :sparkles: allow set state

### DIFF
--- a/src/use-toggle/index.spec.tsx
+++ b/src/use-toggle/index.spec.tsx
@@ -3,24 +3,51 @@ import { render, fireEvent } from '@testing-library/react'
 import { createEvent } from '../testing/utils'
 import useToggle from './index'
 
-const TestComponent: React.FC<{ initialValue: boolean }> = (props) => {
-  const { initialValue } = props
-  const [state, toggle] = useToggle(initialValue)
-  return (
-    <div>
-      <span data-testid={'state'}>{state ? 'on' : 'off'}</span>
-      <button onClick={toggle} data-testid={'toggle'}>
-        toggle
-      </button>
-    </div>
-  )
-}
-
 it('toggle state', () => {
+  const TestComponent: React.FC<{ initialValue: boolean }> = (props) => {
+    const { initialValue } = props
+    const [state, toggle] = useToggle(initialValue)
+    return (
+      <div>
+        <span data-testid={'state'}>{state ? 'on' : 'off'}</span>
+        <button onClick={toggle} data-testid={'toggle'}>
+          toggle
+        </button>
+      </div>
+    )
+  }
   const { getByTestId } = render(<TestComponent initialValue={false} />)
   expect(getByTestId('state').textContent).toBe('off')
   fireEvent(getByTestId('toggle'), createEvent('click', { bubbles: true }))
   expect(getByTestId('state').textContent).toBe('on')
   fireEvent(getByTestId('toggle'), createEvent('click', { bubbles: true }))
+  expect(getByTestId('state').textContent).toBe('off')
+})
+
+it('set state', () => {
+  const TestComponent: React.FC<{ initialValue: boolean }> = (props) => {
+    const { initialValue } = props
+    const [state, toggle, set] = useToggle(initialValue)
+    return (
+      <div>
+        <span data-testid={'state'}>{state ? 'on' : 'off'}</span>
+        <button onClick={() => set(true)} data-testid={'on'}>
+          on
+        </button>
+        <button onClick={() => set(false)} data-testid={'off'}>
+          off
+        </button>
+      </div>
+    )
+  }
+  const { getByTestId } = render(<TestComponent initialValue={false} />)
+  expect(getByTestId('state').textContent).toBe('off')
+  fireEvent(getByTestId('on'), createEvent('click', { bubbles: true }))
+  expect(getByTestId('state').textContent).toBe('on')
+  fireEvent(getByTestId('on'), createEvent('click', { bubbles: true }))
+  expect(getByTestId('state').textContent).toBe('on')
+  fireEvent(getByTestId('off'), createEvent('click', { bubbles: true }))
+  expect(getByTestId('state').textContent).toBe('off')
+  fireEvent(getByTestId('off'), createEvent('click', { bubbles: true }))
   expect(getByTestId('state').textContent).toBe('off')
 })

--- a/src/use-toggle/index.ts
+++ b/src/use-toggle/index.ts
@@ -1,9 +1,10 @@
 import React from 'react'
 
-const useToggle = (initialState: boolean): [boolean, () => void] => {
+const useToggle = (initialState: boolean): [boolean, () => void, (state: boolean) => void] => {
   const [state, setState] = React.useState(initialState)
   const toggle = () => setState((state) => !state)
-  return [state, toggle]
+  const set = (override: boolean) => setState(override)
+  return [state, toggle, set]
 }
 
 export default useToggle


### PR DESCRIPTION
now `useToggle` returns the second helper that allows setting state explicitly