### PR TITLE
chore: :wrench: fix renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,18 +18,18 @@
       "enabled": false
     },
     {
-      "depTypeList": ["devDependencies"],
-      "updateTypes": ["patch", "minor"],
-      "groupName": "devDependencies (non-major)",
-      "groupSlug": "dev-dependencies"
-    },
-    {
       "groupName": "eslint",
       "packagePatterns": ["^@jmdc/eslint-config-", "^@typescript-eslint/", "^eslint"]
     },
     {
       "groupName": "react",
       "packageNames": ["react", "react-dom", "react-test-renderer"]
+    },
+    {
+      "depTypeList": ["devDependencies"],
+      "updateTypes": ["patch", "minor"],
+      "groupName": "devDependencies (non-major)",
+      "groupSlug": "dev-dependencies"
     }
   ]
 }


### PR DESCRIPTION
Moved devDependencies(non-major) to the bottom of packageRules.