### PR TITLE
build: fix secret token name

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -122,5 +122,5 @@ jobs:
       - name: release
         run: yarn semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN_WITH_WRITE_PERMISSION }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_WITH_WRITE_PERMISSION }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
I regenerated the personal token according to the update notice. Also tokens that start with `GITHUB` are no longer accepted.

https://github.community/t/all-github-actions-suddenly-failing-with-github-token-secret-does-not-exist/16108